### PR TITLE
Vouchers file as settings parameter

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -12,5 +12,8 @@
   },
   "giphy": {
     "key": "<your-giphy-api-key-here>"
+  },
+  "vouchers": {
+    "filename": "<your-vouchers-file-name-here>"
   }
 }

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -9,6 +9,7 @@ Command list : \n \
   - **address** : Show an used wallet so you can refill your wallet \n \
   - **withdraw** : Move coins to an external address \n \
   - **qrcode** : Show your qrcode to receive much money \n \
+  - **voucher** : Get your dogecoins from your voucher card !! (Only work in private message with the bot) \n \
 ' + ((GIPHY_KEY !== null && GIPHY_KEY !== '') ? '  - **goodboy** : Wow, much doggo, such reward, wow \n' : '') + ' \
 ```'
 

--- a/src/commands/voucher.js
+++ b/src/commands/voucher.js
@@ -1,8 +1,17 @@
 const { OOPS_TEXT } = require('../messages')
 const path = require('path')
 const jsonfile = require('jsonfile')
+const settings = require('../settings')
+const fs = require('fs')
 
-var vouchersFile = path.join(__dirname, '../vouchers.json')
+var vouchersFile = path.join(__dirname, '..', '..', settings.VOUCHERS_FILENAME)
+
+
+// TODO: We could deactivate the vouchers instead of this
+if (!fs.existsSync(vouchersFile)) {
+  console.error('NO VOUCHERS FILE !!!')
+  process.exit()
+}
 
 const ERROR_NOT_DM_MESSAGE = 'Carefull ! Yoou need to give your voucher code to the bot in a private message !'
 const INVALID_VOUCHER = 'Invalid voucher code'

--- a/src/settings.js
+++ b/src/settings.js
@@ -10,5 +10,6 @@ settings.RPC_PORT = process.env.RPC_PORT || config.rpc.port
 settings.RPC_USER = process.env.RPC_USER || config.rpc.user
 settings.RPC_PASSWORD = process.env.RPC_PASSWORD || config.rpc.password
 settings.GIPHY_KEY = process.env.GIPHY_KEY || config.giphy.key
+settings.VOUCHERS_FILENAME = process.env.VOUCHERS_FILENAME || config.vouchers.filename
 
 module.exports = settings

--- a/vouchers-example.json
+++ b/vouchers-example.json
@@ -1,0 +1,29 @@
+{
+  "vouchers":[
+    "MHTTKR",
+    "JHSYZI",
+    "PUXQHX",
+    "EULXYE",
+    "BFUYWP",
+    "QCOJVO",
+    "WYOPFU",
+    "BJLZES",
+    "CUCSBS",
+    "BEISOY",
+    "REICJZ",
+    "PLNVJV",
+    "KMOMOG",
+    "MQMRIJ",
+    "DTQZSD",
+    "DPIRPV",
+    "YKMPIX",
+    "GBKKVF",
+    "NIGJVX",
+    "HJTJBL",
+    "UGXYMC",
+    "UXOPWN",
+    "JYFPYA",
+    "OZOHVD",
+    "COKFCG"
+  ]
+}


### PR DESCRIPTION
Adding the path of the vouchers json file as a setting parameter instead of hardcoded it. It should be easier to switch between dev and production.

Temporary solution until we implement a proper database (like leveldb).